### PR TITLE
Dockerfile reference with templateflow integration and code from local branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# python cache
+.cache/
+__pycache__/**/*
+__pycache__
+*.pyc
+
+# python distribution
+build/**/*
+build
+dist/**/*
+dist
+*.egg-info/**/*
+*.egg-info
+.eggs/**/*
+.eggs
+src/**/*
+src/
+notebooks/
+.maint/
+.maint/**/*
+
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ RUN pip install --upgrade pip && pip3 install -e .
 
 ENV TEMPLATEFLOW_HOME=${TEMPLATEFLOW_HOME}
 
+RUN git submodule update --init --recursive && python3 tools/download_templates.py
+
 ENTRYPOINT ["/usr/local/bin/giga_connectome"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.9
+
+ARG DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        git && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG TEMPLATEFLOW_HOME="/templateflow"
+
+RUN pip3 install nilearn==0.9.2 templateflow pybids h5py tqdm&& \
+    mkdir -p /code && mkdir -p /templateflow
+
+WORKDIR /code
+
+RUN python3 -c "from templateflow.api import get; get(['MNI152NLin2009cAsym', 'MNI152NLin6Asym'])"
+
+COPY [".", "/code"]
+
+RUN pip install --upgrade pip && pip3 install -e .
+
+ENV TEMPLATEFLOW_HOME=${TEMPLATEFLOW_HOME}
+
+ENTRYPOINT ["/usr/local/bin/giga_connectome"]


### PR DESCRIPTION
PR done in response to the different issues raised in PR #12 and issue #13.

The Dockerfile present the following characteristics:
- use the python:3.9 docker as base image, 
- set the TEMPLATEFLOW_HOME to /templateflow and caches the different required TemplateFlow atlases,
- download and build additional template using the script located in tools/download_templates.py,
- install the package from the current local branch.

Example usage:
`sudo docker image build -t gigaconnectome:main -f Dockerfile .`
`sudo docker run -it -v <path_to_bids_dataset>:/data -v <path_to_output_folder>:/outputs -v <path_to_config_folder>:/config gigaconnectome:main /data /outputs participant --bids-filter-file /config/bids_filters.json
`

